### PR TITLE
Keeping wallet connection when move page or refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "antd": "^5.16.4",
         "next": "14.2.2",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "recoil": "^0.7.7"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -2825,6 +2826,11 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -4950,6 +4956,25 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
+      "integrity": "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "next": "14.2.2",
         "react": "^18",
         "react-dom": "^18",
-        "recoil": "^0.7.7"
+        "recoil": "^0.7.7",
+        "recoil-persist": "^5.1.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -4975,6 +4976,14 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "antd": "^5.16.4",
     "next": "14.2.2",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "recoil": "^0.7.7"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "next": "14.2.2",
     "react": "^18",
     "react-dom": "^18",
-    "recoil": "^0.7.7"
+    "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,21 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import Layout, { Content, Footer, Header } from "antd/lib/layout/layout";
 import "./globals.css";
-
-const headerStyle: React.CSSProperties = {
-  textAlign: "center",
-  fontSize: "48px",
-  height: 64,
-  paddingInline: 48,
-  lineHeight: "64px",
-  backgroundColor: "#ffffff",
-};
-
-const contentStyle: React.CSSProperties = {
-  textAlign: "center",
-  minHeight: "80%",
-  height: "80%",
-};
+import RecoilRootWrapper from "@/containers/recoilRootWrapper";
 
 const footerStyle: React.CSSProperties = {
   textAlign: "center",
@@ -49,10 +35,9 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <Layout style={layoutStyle}>
-          <Header style={headerStyle}>AI Network Chatbot Arena</Header>
-          <Content style={contentStyle}>
-              {children}
-          </Content>
+          <RecoilRootWrapper>
+            {children}
+          </RecoilRootWrapper>
           <Footer style={footerStyle}>Powered by AI Network © 2024</Footer>
         </Layout>
       </body>

--- a/src/components/arenaHeader.tsx
+++ b/src/components/arenaHeader.tsx
@@ -1,0 +1,25 @@
+import { Button, Col, Row, Space } from "antd";
+import { Header } from "antd/lib/layout/layout";
+import WalletConnectBtn from "./walletConnectBtn";
+
+const headerStyle: React.CSSProperties = {
+  textAlign: "left",
+  fontSize: "48px",
+  height: 64,
+  paddingInline: 48,
+  lineHeight: "64px",
+  backgroundColor: "#ffffff",
+};
+
+export default function ArenaHeader() {
+  return (
+    <Header style={headerStyle}>
+      <Row>
+        <Col span={22} style={{fontSize: "48px"}}>AI Network Chatbot Arena</Col>
+        <Col span={2}>
+          <WalletConnectBtn />
+        </Col>
+      </Row>
+    </Header>
+  );
+}

--- a/src/components/walletConnectBtn.tsx
+++ b/src/components/walletConnectBtn.tsx
@@ -3,14 +3,17 @@
 import { requestAddress } from "@/lib/wallet";
 import { WalletOutlined } from "@ant-design/icons";
 import { Button, Modal, Space } from "antd";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRecoilState } from "recoil";
-import { addressAtom } from "@/lib/wallet";
+import { addressAtom, useSsrCompletedState } from "@/lib/wallet";
 
 export default function WalletConnectBtn() {
   const [modalOpen, setModalOpen] = useState(false);
   const [modalLoading, setModalLoading] = useState(false);
   const [address, setAddress] = useRecoilState(addressAtom);
+
+  const setSsrCompleted = useSsrCompletedState();
+  useEffect(setSsrCompleted, [setSsrCompleted]);
 
   const onClickConnectWalletBtn = async () => {
     if(address !== "") {

--- a/src/components/walletConnectBtn.tsx
+++ b/src/components/walletConnectBtn.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { requestAddress } from "@/lib/wallet";
+import { WalletOutlined } from "@ant-design/icons";
+import { Button, Modal, Space } from "antd";
+import { useState } from "react";
+
+export default function WalletConnectBtn() {
+  const [address, setAddress] = useState<string>("");
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalLoading, setModalLoading] = useState(false);
+
+  const onClickConnectWalletBtn = async () => {
+    if(address !== "") {
+      return;
+    }
+    const getAddress = await requestAddress();
+    if(getAddress === undefined){
+      setModalOpen(true);
+      return;
+    }
+    setAddress(getAddress);
+  }
+
+  const handleOk = () => {
+    setModalOpen(false);
+  };
+
+  return (
+    <Space>
+      <Button onClick={onClickConnectWalletBtn}>
+        <WalletOutlined />{address ? address.slice(0,8)+"..." : "connect wallet"} 
+      </Button>
+      <Modal
+        open={modalOpen}
+        title="Ain Wallet not found"
+        onOk={handleOk}
+        onCancel={handleOk}
+        footer={[
+          <Button
+            key="link"
+            href="https://chromewebstore.google.com/detail/ain-wallet/hbdheoebpgogdkagfojahleegjfkhkpl?hl=ko"
+            type="primary"
+            loading={modalLoading}
+            onClick={handleOk}
+          >
+            Install AIN wallet extention
+          </Button>,
+        ]}
+      >
+        <p>You should install AIN wallet first.</p>
+      </Modal>
+    </Space>
+  );
+}

--- a/src/components/walletConnectBtn.tsx
+++ b/src/components/walletConnectBtn.tsx
@@ -4,11 +4,13 @@ import { requestAddress } from "@/lib/wallet";
 import { WalletOutlined } from "@ant-design/icons";
 import { Button, Modal, Space } from "antd";
 import { useState } from "react";
+import { useRecoilState } from "recoil";
+import { addressAtom } from "@/lib/wallet";
 
 export default function WalletConnectBtn() {
-  const [address, setAddress] = useState<string>("");
   const [modalOpen, setModalOpen] = useState(false);
   const [modalLoading, setModalLoading] = useState(false);
+  const [address, setAddress] = useRecoilState(addressAtom);
 
   const onClickConnectWalletBtn = async () => {
     if(address !== "") {

--- a/src/containers/arenaChat.tsx
+++ b/src/containers/arenaChat.tsx
@@ -2,12 +2,14 @@
 
 import ChatBox from "@/components/chatBox";
 import PromptInput from "@/components/promptInput";
-import { Button, Col, Flex, Modal, Row, Space, message, notification } from "antd";
+import { Button, Col, Flex, Row, Space, notification } from "antd";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { chatResult, chatReward, chatWithModel } from "@/lib/arena";
 import { ArenaStatus, ChoiceType } from "@/type";
 import ChoiceButton from "@/components/choiceButton";
+import { useRecoilState } from "recoil";
+import { addressAtom } from "@/lib/wallet";
 
 type ArenaChatProps = {
   modelA: string,
@@ -18,7 +20,7 @@ export default function ArenaChat({modelA, modelB}: ArenaChatProps) {
   const router = useRouter();
 
   const [prompt, setPrompt] = useState("");
-  const [address, setAddress] = useState<string>("");
+  const [address, setAddress] = useRecoilState (addressAtom);
   const [status, setStatus] = useState<ArenaStatus>(ArenaStatus.NOTCONNECTED);
   const [modelAName, setModelAName] = useState("");
   const [modelBName, setModelBName] = useState("");
@@ -50,7 +52,7 @@ export default function ArenaChat({modelA, modelB}: ArenaChatProps) {
   }, [status])
 
   useEffect(()=> {
-    if(address !== "") {
+    if (address !== "") {
       setStatus(ArenaStatus.READY)
     }
   }, [address])

--- a/src/containers/arenaChat.tsx
+++ b/src/containers/arenaChat.tsx
@@ -91,8 +91,8 @@ export default function ArenaChat({modelA, modelB}: ArenaChatProps) {
         }]
       })
       setStatus(ArenaStatus.END);
-      const reward = chatReward(battleId)
-      openNotification(await reward)
+      const reward = chatReward(battleId);
+      openNotification(await reward);
     } catch (err) {
       alert(`${err}.\n If the error is repeated, please refresh the page.`);
     }

--- a/src/containers/arenaChat.tsx
+++ b/src/containers/arenaChat.tsx
@@ -7,8 +7,6 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { chatResult, chatReward, chatWithModel } from "@/lib/arena";
 import { ArenaStatus, ChoiceType } from "@/type";
-import { requestAddress } from "@/lib/wallet";
-import { WalletOutlined } from "@ant-design/icons";
 import ChoiceButton from "@/components/choiceButton";
 
 type ArenaChatProps = {
@@ -27,8 +25,6 @@ export default function ArenaChat({modelA, modelB}: ArenaChatProps) {
   const [resultA, setResultA] = useState("");
   const [resultB, setResultB] = useState("");
   const [notiApi, notiContextHolder] = notification.useNotification();
-  const [modalLoading, setModalLoading] = useState(false);
-  const [modalOpen, setModalOpen] = useState(false);
   
   const openNotification = (rewardData: any) => {
     console.log(rewardData);
@@ -64,22 +60,6 @@ export default function ArenaChat({modelA, modelB}: ArenaChatProps) {
     setStatus(ArenaStatus.READY);
     setResultA("");
     setResultB("");
-  }
-
-  const handleOk = () => {
-    setModalOpen(false);
-  };
-
-  const onClickConnectWalletBtn = async () => {
-    if(address !== "") {
-      return;
-    }
-    const getAddress = await requestAddress();
-    if(getAddress === undefined){
-      setModalOpen(true);
-      return;
-    }
-    setAddress(getAddress)
   }
 
   const onClickChoiceBtn = async (value: ChoiceType) => {
@@ -138,26 +118,6 @@ export default function ArenaChat({modelA, modelB}: ArenaChatProps) {
   return (
     <Space direction="vertical" size="middle" style={{ display: 'flex' }}>
       {notiContextHolder}
-      <Modal
-        open={modalOpen}
-        title="Ain Wallet not found"
-        onOk={handleOk}
-        onCancel={handleOk}
-        footer={[
-          <Button
-            key="link"
-            href="https://chromewebstore.google.com/detail/ain-wallet/hbdheoebpgogdkagfojahleegjfkhkpl?hl=ko"
-            type="primary"
-            loading={modalLoading}
-            onClick={handleOk}
-          >
-            Install AIN wallet extention
-          </Button>,
-        ]}
-      >
-        <p>You should install AIN wallet first.</p>
-      </Modal>
-      <Button onClick={onClickConnectWalletBtn} ><WalletOutlined />{address ? address.slice(0,8)+"..." : "connect wallet"} </Button>
       <Flex justify="space-between">
         <ChatBox modelName={modelAName} status={status} prompt={resultA} />
         <ChatBox modelName={modelBName} status={status} prompt={resultB} />

--- a/src/containers/arenaChat.tsx
+++ b/src/containers/arenaChat.tsx
@@ -53,7 +53,9 @@ export default function ArenaChat({modelA, modelB}: ArenaChatProps) {
 
   useEffect(()=> {
     if (address !== "") {
-      setStatus(ArenaStatus.READY)
+      setStatus(ArenaStatus.READY);
+    } else {
+      setStatus(ArenaStatus.NOTCONNECTED);
     }
   }, [address])
 

--- a/src/containers/recoilRootWrapper.tsx
+++ b/src/containers/recoilRootWrapper.tsx
@@ -1,20 +1,12 @@
 "use client";
 
+import ArenaHeader from "@/components/arenaHeader";
 import { Content, Header } from "antd/lib/layout/layout";
 import { RecoilRoot } from "recoil";
 
 type RecoilRootWrapperProps = {
   children: React.ReactNode,
 }
-
-const headerStyle: React.CSSProperties = {
-  textAlign: "center",
-  fontSize: "48px",
-  height: 64,
-  paddingInline: 48,
-  lineHeight: "64px",
-  backgroundColor: "#ffffff",
-};
 
 const contentStyle: React.CSSProperties = {
   textAlign: "center",
@@ -25,7 +17,7 @@ const contentStyle: React.CSSProperties = {
 export default function RecoilRootWrapper({ children }: RecoilRootWrapperProps) {
   return (
     <RecoilRoot>
-      <Header style={headerStyle}>AI Network Chatbot Arena</Header>
+      <ArenaHeader />
       <Content style={contentStyle}>
           {children}
       </Content>  

--- a/src/containers/recoilRootWrapper.tsx
+++ b/src/containers/recoilRootWrapper.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Content, Header } from "antd/lib/layout/layout";
+import { RecoilRoot } from "recoil";
+
+type RecoilRootWrapperProps = {
+  children: React.ReactNode,
+}
+
+const headerStyle: React.CSSProperties = {
+  textAlign: "center",
+  fontSize: "48px",
+  height: 64,
+  paddingInline: 48,
+  lineHeight: "64px",
+  backgroundColor: "#ffffff",
+};
+
+const contentStyle: React.CSSProperties = {
+  textAlign: "center",
+  minHeight: "80%",
+  height: "80%",
+};
+
+export default function RecoilRootWrapper({ children }: RecoilRootWrapperProps) {
+  return (
+    <RecoilRoot>
+      <Header style={headerStyle}>AI Network Chatbot Arena</Header>
+      <Content style={contentStyle}>
+          {children}
+      </Content>  
+    </RecoilRoot>);
+}

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -1,9 +1,15 @@
 import { Signer } from "@ainblockchain/ain-js/lib/signer/signer";
+import { atom } from "recoil";
 
 export const requestAddress = async () => {
-  const walletExtension:Signer = window.ainetwork;
+  const walletExtension: Signer = window.ainetwork;
   if (walletExtension) {
     const address = await walletExtension.getAddress();
     return address
   }
 };
+
+export const addressAtom = atom({
+  key: "address",
+  default: "",
+})

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -1,5 +1,8 @@
 import { Signer } from "@ainblockchain/ain-js/lib/signer/signer";
-import { atom } from "recoil";
+import { atom, useSetRecoilState, AtomEffect } from "recoil";
+import { recoilPersist } from "recoil-persist";
+
+const { persistAtom } = recoilPersist();
 
 export const requestAddress = async () => {
   const walletExtension: Signer = window.ainetwork;
@@ -9,7 +12,22 @@ export const requestAddress = async () => {
   }
 };
 
+const ssrCompletedState = atom({
+  key: "SsrCompleted",
+  default: false,
+})
+
+export const useSsrCompletedState = () => {
+  const setSsrCompleted = useSetRecoilState(ssrCompletedState)
+  return () => setSsrCompleted(true);
+}
+
+export const persistAtomEffect = <T>(param: Parameters<AtomEffect<T>>[0]) => {
+  param.getPromise(ssrCompletedState).then(() => persistAtom(param))
+}
+
 export const addressAtom = atom({
   key: "address",
   default: "",
+  effects_UNSTABLE: [persistAtomEffect],
 })


### PR DESCRIPTION
Updates
- Wallet connect 버튼을 header 로 옮겼습니다.
- 페이지를 새로고침하거나 리더보드 <-> 아레나 이동해도 커넥트가 끊기지 않도록 변경하였습니다.