### PR TITLE
Minor UI Fix

### DIFF
--- a/src/app/api/arena/reward/[id]/route.ts
+++ b/src/app/api/arena/reward/[id]/route.ts
@@ -1,5 +1,6 @@
 import { chatReward } from "@/app/api/arena/arena";
 import { NextRequest } from "next/server";
+import { ZERO_REWARD_MSG } from "@/constant/constant";
 
 export async function GET(
   req: NextRequest, 
@@ -15,8 +16,8 @@ export async function GET(
     const errRes = {
       reward: 0,
       score: 0,
-      reason: "",
-      tx_hash: "Something fault. Please retry the chat.",
+      reason: "Something fault. Please retry the chat.",
+      tx_hash: ZERO_REWARD_MSG,
     };
     console.log('errRes :>> ', errRes);
     return Response.json(errRes, {

--- a/src/app/api/arena/reward/[id]/route.ts
+++ b/src/app/api/arena/reward/[id]/route.ts
@@ -12,7 +12,14 @@ export async function GET(
       status: 200,
     });
   } catch (error) {
-    return Response.json("", {
+    const errRes = {
+      reward: 0,
+      score: 0,
+      reason: "",
+      tx_hash: "Something fault. Please retry the chat.",
+    };
+    console.log('errRes :>> ', errRes);
+    return Response.json(errRes, {
       status: 500,
     });
   }

--- a/src/components/arenaHeader.tsx
+++ b/src/components/arenaHeader.tsx
@@ -19,7 +19,7 @@ export default function ArenaHeader() {
         flex: "none",
         fontSize: "32px",
         fontWeight: "bold",
-        }}>AI Network Chatbot Arena</div>
+        }}>AI Network LLM Arena</div>
       <div style={{
         marginLeft: "auto",
       }}>

--- a/src/components/rewardProgress.tsx
+++ b/src/components/rewardProgress.tsx
@@ -10,6 +10,7 @@ export default function RewardProgress() {
     '0%': '#108ee9',
     '100%': '#87d068',
   };
+  
   useEffect(() => {
     const getRewardPercent = async () => {
       try {
@@ -23,10 +24,15 @@ export default function RewardProgress() {
     getRewardPercent();
   }, [])
 
+  const percentFix = (percent: number) => {
+    const fixedString = percent.toFixed(2);
+    return Number(fixedString);
+  }
+
   return (
     <Flex gap="small" justify="flex-start" style={{ width: 600, marginBottom: "8px" }}>
       <div style={{minWidth: 260}}><h3>💰TODAY AIN REWARD REMAIN</h3></div>
-      <Progress percent={Math.max(100 - percent, 0)} strokeColor={twoColors} size="small" status="active"/>
+      <Progress percent={percentFix(Math.max(100 - percent, 0))} strokeColor={twoColors} size="small" status="active"/>
     </Flex>
   )
 }

--- a/src/constant/constant.ts
+++ b/src/constant/constant.ts
@@ -1,4 +1,4 @@
-
+export const ZERO_REWARD_MSG = "NO TX FOR 0 REWARD";
 
 export const getGAId = () => {
   return process.env.NODE_ENV === "production" ? "G-TFVPRQGF0M" : "G-WHKH2Q8EJY"

--- a/src/containers/arenaChat.tsx
+++ b/src/containers/arenaChat.tsx
@@ -42,11 +42,11 @@ export default function ArenaChat() {
   const [notiApi, notiContextHolder] = notification.useNotification();
   
   const openNotification = (rewardData: any) => {
-    const isZeroScore = rewardData.score === 0;
+    const isZeroReward = rewardData.reward === 0;
     notiApi.info({
-      message: isZeroScore ? "Reward failed." : "Reward Success!",
+      message: isZeroReward ? "Reward Failed." : "Reward Success!",
       description:
-        isZeroScore ? "Prompt was not meaningful for us. Try different prompt!" : `Reward: ${rewardData.reward} AIN`,
+        isZeroReward ? rewardData.tx_hash : `Reward: ${rewardData.reward} AIN`, // NOTE(yoojin): If the reward is not issued, the reason will be provided via "tx_hash".
       placement: "topRight",
       duration: 0,
     });
@@ -138,7 +138,8 @@ export default function ArenaChat() {
       const reward = await fetch(`/api/arena/reward/${battleId}`, {
         method: "GET",
       });
-      openNotification(await reward.json());
+      const rewardData = await reward.json();
+      openNotification(rewardData);
     } catch (err) {
       alert(`${err}.\n If the error is repeated, please refresh the page.`);
     }

--- a/src/containers/arenaChat.tsx
+++ b/src/containers/arenaChat.tsx
@@ -5,7 +5,7 @@ import PromptInput from "@/components/promptInput";
 import { Button, Col, Flex, Row, Space, notification } from "antd";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { APIStatus, ArenaStatus, ChatResultReqBody, ChoiceType } from "@/type";
+import { ArenaStatus, ChatResultReqBody, ChoiceType } from "@/type";
 import ChoiceButton from "@/components/choiceButton";
 import { useRecoilState } from "recoil";
 import { addressAtom } from "@/lib/wallet";
@@ -46,7 +46,7 @@ export default function ArenaChat() {
     notiApi.info({
       message: isZeroReward ? "Reward Failed." : "Reward Success!",
       description:
-        isZeroReward ? rewardData.tx_hash : `Reward: ${rewardData.reward} AIN`, // NOTE(yoojin): If the reward is not issued, the reason will be provided via "tx_hash".
+        isZeroReward ? rewardData.reason : `Reward: ${rewardData.reward} AIN`, // NOTE(yoojin): If the reward is not issued, the reason will be provided via "tx_hash".
       placement: "topRight",
       duration: 0,
     });


### PR DESCRIPTION
Updates
- 500 Error 등으로 reward failed 날 경우 메시지 추가
- 제목 변경 ( AI Network Chatbot Arena -> AI Network LLM Arena )
- progress bar percent 최대 소수점 2자리 까지만 표기되도록 변경
- Reward Failed error message 서버 메시지를 출력하도록 변경 (추가 논의 필요)