### PR TITLE
Change wallet network phrase to be kind

### DIFF
--- a/src/components/walletConnectBtn.tsx
+++ b/src/components/walletConnectBtn.tsx
@@ -89,7 +89,7 @@ export default function WalletConnectBtn() {
 
     if (invalidChainModalOpen) {
       return (
-        <Tooltip title={`Unsupported network (${PUBLIC_ENV.APP_ENV!=="production" ? "Mainnet" : "Testnet"}).`} placement="bottom" open>{text}</Tooltip>
+        <Tooltip overlay={<>{`Incorrect network selected.`}<br />{`Please switch to ${PUBLIC_ENV.APP_ENV === "production" ? "Mainnet" : "Testnet"}.`}</>} placement="bottom" open>{text}</Tooltip>
       )
     }
     return text;


### PR DESCRIPTION
Updates
- Wallet network 잘못 선택시 출력되는 팝업 문구를 변경하였습니다. 
 Unsupported network -> Incorrect network selected. please switch to {network} 