### PR TITLE
Check auth tokens before fetch

### DIFF
--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -15,13 +15,17 @@ export async function POST(req: NextRequest) {
   try {
     const result = await fetch(endpoint, {
       method: "GET",
-      headers: { Cookie: `refresh_token=${refreshToken?.value};` },
+      headers: { 
+        Cookie: `refresh_token=${refreshToken?.value};`,
+        "x-api-key": process.env.SERVER_API_KEY!,
+      },
     });
     const refreshResult = await result.json();
     const { access_token } = refreshResult;
     access_token.expire = Math.round(access_token.expire * 1000);
     return Response.json(access_token, { status: 200 });
   } catch (e) {
+    console.log("Refresh Error", e);
     return Response.json(failedRefresh, { status: 500 });
   }
 }

--- a/src/containers/arenaChat.tsx
+++ b/src/containers/arenaChat.tsx
@@ -9,7 +9,7 @@ import { ArenaStatus, CaptchaStatus, Chat, ChoiceType } from "@/src/types/type";
 import { useGoogleReCaptcha } from "react-google-recaptcha-v3";
 import React from "react";
 import { useSession } from "next-auth/react";
-import { authFetch } from "@/src/lib/auth";
+import useAuth from "@/src/lib/auth";
 import { toast } from "sonner";
 import { processNumber } from "../constant/constant";
 
@@ -44,6 +44,7 @@ export default function ArenaChat() {
   const [turn, setTurn] = useState(0);
 
   const { data: session, update } = useSession();
+  const { authFetch, checkAuth } = useAuth();
 
   const testCaptcha = async () => {
     if (!executeRecaptcha) {
@@ -244,7 +245,9 @@ export default function ArenaChat() {
       setModelAChatList([...modelAChatList, userChat]);
       setModelBChatList([...modelBChatList, userChat]);
       try {
-        authFetch("/api/arena/chat", {
+        // NOTE(yoojin): Inference 가 동시에 두 번 요청가기 때문에 미리 auth check 후 일반 fetch 사용
+        await checkAuth();
+        fetch("/api/arena/chat", {
           method: "POST",
           body: JSON.stringify({
             battleId,
@@ -261,7 +264,7 @@ export default function ArenaChat() {
             },
           ]);
         });
-        authFetch("/api/arena/chat", {
+        fetch("/api/arena/chat", {
           method: "POST",
           body: JSON.stringify({
             battleId,


### PR DESCRIPTION
Updates
- fetch 전 access token, refresh token 을 확인하는 authFetch 를 실질적 적용했습니다. (이전까진 함수만 사용)
- 동시에 두 번의 요청이 가는 inference 과정에서는 checkAuth 함수만 fetch 전 먼저 실행하도록 하였습니다.

Need test
- Refresh token 만료 테스트 필요